### PR TITLE
Added exit() if no reads are found for mapping

### DIFF
--- a/Reads.c
+++ b/Reads.c
@@ -702,6 +702,7 @@ int readChunk(Read **seqList, unsigned int *seqListSize)
 	else if (_r_firstIteration)
 	{
 		fprintf(stdout, "ERR: No reads for mapping\n");
+		exit("EXIT_FAILURE");
 	}
 
 	if (_r_seqCnt < _r_maxSeqCnt)		// reached end of file


### PR DESCRIPTION
This makes it so that mrsfast no longer segfaults if given an empty input file. It will now produce a samfile with only a header.