### PR TITLE
changes related to parameters & default files - v3.4.1

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,8 @@
+2018-11-12  Can Alkan  <calkan@gmail.com>
+	* Default output file is now (seqFile1)-output.sam(.gz) & default nohit file is (seqFile1)-output.nohit.fastq(.gz)
+	* No-hit FASTQ output is new also compressed when --outcomp parameter is used.
+	* mrsFAST now accepts -t as a short form for --threads.
+
 2014-03-31  Faraz Hach  <fhach@sfu.ca>
 	* Added with-sse4 option to Makefile
 	* Bug reported by viktor in dc mode is fixed.

--- a/CommandLineParser.c
+++ b/CommandLineParser.c
@@ -152,7 +152,7 @@ int parseCommandLine (int argc, char *argv[])
 
 
 
-	while ( (o = getopt_long ( argc, argv, "f:i:u:o:s:e:n:bhv", longOptions, &index))!= -1 )
+	while ( (o = getopt_long ( argc, argv, "f:i:u:o:s:e:n:t:bhv", longOptions, &index))!= -1 )
 	{
 		switch (o)
 		{
@@ -359,6 +359,17 @@ int parseCommandLine (int argc, char *argv[])
 	char fname4[FILE_NAME_LENGTH];
 	char fname5[FILE_NAME_LENGTH];
 
+	/* change defaut output filenames */
+	if (!strcmp(mappingOutput, "output"))
+	  {
+	    stripPath (seqFile1, &mappingOutputPath, &mappingOutput);
+	    sprintf(mappingOutput, "%s-output", seqFile1);
+	    if (!outCompressed)
+	      sprintf(unmappedOutput, "%s-output.nohit.fastq", seqFile1 );	    
+	    else
+	      sprintf(unmappedOutput, "%s-output.nohit.fastq.gz", seqFile1 );	    
+	  }
+	
 	// Why is this one here?
 	if (pairedEndMode)
 	{

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-MRSFAST_VERSION := "3.4.0"
+MRSFAST_VERSION := "3.4.1"
 BUILD_DATE := "$(shell date)"
 
 all: OPTIMIZE_FLAGS build

--- a/Output.c
+++ b/Output.c
@@ -187,8 +187,8 @@ int initOutput ( char *fileName, int compressed)
 		}
 		else
 		{
-			//sprintf(newFileName, "%s%s.sam", mappingOutputPath, fileName);
-			sprintf(newFileName, "%s%s", mappingOutputPath, fileName);
+		        sprintf(newFileName, "%s%s.sam", mappingOutputPath, fileName);
+			//sprintf(newFileName, "%s%s", mappingOutputPath, fileName);
 		}
 
 		_out_fp = fileOpen(newFileName, "w");

--- a/Reads.c
+++ b/Reads.c
@@ -47,6 +47,7 @@
 FILE *_r_fp1;
 FILE *_r_fp2;
 FILE *_r_umfp;
+gzFile _r_gzumfp;
 gzFile _r_gzfp1;
 gzFile _r_gzfp2;
 Read *_r_seq;
@@ -580,7 +581,10 @@ int initRead(char *fileName1, char *fileName2)
 
 	if (!nohitDisabled)
 	{
-		_r_umfp = fileOpen(unmappedOutput, "w");
+	  if (!outCompressed)
+	    _r_umfp = fileOpen(unmappedOutput, "w");
+	  else 
+	    _r_gzumfp = fileOpenGZ(unmappedOutput, "w");
 	}
 
 	_r_alphIndex = getMem(128);		// used in readChunk()
@@ -736,22 +740,34 @@ void outputUnmapped()
 		{
 			if (_r_seq[2*i].hits[0] == 0 && _r_fastq)
 			{
-				fprintf(_r_umfp,"@%s/1\n%s\n+\n%s\n@%s/2\n%s\n+\n%s\n", _r_seq[i*2].name, _r_seq[i*2].seq, _r_seq[i*2].qual, _r_seq[i*2].name, _r_seq[i*2+1].seq, _r_seq[i*2+1].qual);
+			        if (!outCompressed)
+				  fprintf(_r_umfp,"@%s/1\n%s\n+\n%s\n@%s/2\n%s\n+\n%s\n", _r_seq[i*2].name, _r_seq[i*2].seq, _r_seq[i*2].qual, _r_seq[i*2].name, _r_seq[i*2+1].seq, _r_seq[i*2+1].qual);
+				else
+				  gzprintf(_r_gzumfp,"@%s/1\n%s\n+\n%s\n@%s/2\n%s\n+\n%s\n", _r_seq[i*2].name, _r_seq[i*2].seq, _r_seq[i*2].qual, _r_seq[i*2].name, _r_seq[i*2+1].seq, _r_seq[i*2+1].qual);
 			}
 			else if (_r_seq[2*i].hits[0] == 0)
 			{
-				fprintf(_r_umfp, ">%s/1\n%s\n>%s/2\n%s\n", _r_seq[i*2].name, _r_seq[i*2].seq, _r_seq[i*2].name, _r_seq[i*2+1].seq);
+			        if (!outCompressed)
+				  fprintf(_r_umfp, ">%s/1\n%s\n>%s/2\n%s\n", _r_seq[i*2].name, _r_seq[i*2].seq, _r_seq[i*2].name, _r_seq[i*2+1].seq);
+				else
+				  gzprintf(_r_gzumfp, ">%s/1\n%s\n>%s/2\n%s\n", _r_seq[i*2].name, _r_seq[i*2].seq, _r_seq[i*2].name, _r_seq[i*2+1].seq);
 			}
 		}
 		else
 		{
 			if (_r_seq[i].hits[0] == 0 && _r_fastq)
 			{
-				fprintf(_r_umfp,"@%s\n%s\n+\n%s\n", _r_seq[i].name, _r_seq[i].seq, _r_seq[i].qual);
+			        if (!outCompressed)
+				  fprintf(_r_umfp,"@%s\n%s\n+\n%s\n", _r_seq[i].name, _r_seq[i].seq, _r_seq[i].qual);
+				else
+				  gzprintf(_r_gzumfp,"@%s\n%s\n+\n%s\n", _r_seq[i].name, _r_seq[i].seq, _r_seq[i].qual);				
 			}
 			else if (_r_seq[i].hits[0] == 0)
 			{
-				fprintf(_r_umfp,">%s\n%s\n", _r_seq[i].name, _r_seq[i].seq);
+			        if (!outCompressed)
+				  fprintf(_r_umfp,">%s\n%s\n", _r_seq[i].name, _r_seq[i].seq);
+				else 
+				  gzprintf(_r_gzumfp,">%s\n%s\n", _r_seq[i].name, _r_seq[i].seq);
 			}
 		}
 	}
@@ -830,7 +846,10 @@ void finalizeReads()
 
 	if (!nohitDisabled)
 	{
-		fclose(_r_umfp);
+	        if (!outCompressed)
+		  fclose(_r_umfp);
+		else
+		  gzclose(_r_gzumfp);	    
 	}
 }
 


### PR DESCRIPTION
	* Default output file is now (seqFile1)-output.sam(.gz) & default nohit file is (seqFile1)-output.nohit.fastq(.gz)
	* No-hit FASTQ output is new also compressed when --outcomp parameter is used.
	* mrsFAST now accepts -t as a short form for --threads.
