### PR TITLE
fix: modern-GCC build flags, SSE4 detection, and paired-end segfault (v3.4.3)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,19 +9,19 @@ build: clean_executables SSE_FLAGS mrsfast snp_indexer clean_objects
 
 
 LIBS=-lz -lm -pthread -lpthread
-CFLAGS=-fno-pic -DMRSFAST_VERSION=\"$(MRSFAST_VERSION)\" -DBUILD_DATE=\"$(BUILD_DATE)\"
+CFLAGS=-fno-pic -fcommon -DMRSFAST_VERSION=\"$(MRSFAST_VERSION)\" -DBUILD_DATE=\"$(BUILD_DATE)\"
 
 objects=baseFAST.o Sort.o MrsFAST.o Common.o CommandLineParser.o RefGenome.o HashTable.o Reads.o Output.o SNPReader.o  HELP.o
 
 mrsfast: clean_executables $(objects)
 ifeq ($(shell uname -s),Linux)
-	$(CC) -w $(objects) -o $@ ${LDFLAGS} ${LIBS}
+	$(CC) -no-pie -w $(objects) -o $@ ${LDFLAGS} ${LIBS}
 else
 	$(CC) -Wl,-no_pie -fno-pic -w $(objects) -o $@ ${LDFLAGS} ${LIBS}
 endif
 
 snp_indexer: clean_executables SNPIndexer.o
-	$(CC) SNPIndexer.o -o $@ ${LDFLAGS} ${LIBS}
+	$(CC) -no-pie SNPIndexer.o -o $@ ${LDFLAGS} ${LIBS}
 
 clean_objects: mrsfast snp_indexer
 	@rm -f $(objects)
@@ -68,7 +68,7 @@ else
         	$(eval CFLAGS = $(CFLAGS) \
         	$(shell gv=`$(CC) -dumpversion`; \
             	    sc=`grep -c "sse4" /proc/cpuinfo`; \
-                	echo $$sc.$$gv | awk -F. '{if($$1>0 && $$2>=4 && $$3>=4) print "-DSSE4=1 -msse4.2"; else print "-DSSE4=0"}'))
+                	echo $$sc.$$gv | awk -F. '{if($$1>0 && ($$2>4 || ($$2==4 && $$3>=4))) print "-DSSE4=1 -msse4.2"; else print "-DSSE4=0"}'))
 endif
 else
 ifeq ($(with-sse4),no)
@@ -77,6 +77,6 @@ else
         $(eval CFLAGS = $(CFLAGS) \
         $(shell gv=`$(CC) -dumpversion`; \
                 sc=`sysctl -n machdep.cpu.features | grep -c "SSE4"` ;\
-                echo $$sc.$$gv | awk -F. '{if($$1>0 && $$2>=4 && $$3>=4) print "-DSSE4=1 -msse4.2"; else print "-DSSE4=0"}'))
+                echo $$sc.$$gv | awk -F. '{if($$1>0 && ($$2>4 || ($$2==4 && $$3>=4))) print "-DSSE4=1 -msse4.2"; else print "-DSSE4=0"}'))
 endif
 endif

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-MRSFAST_VERSION := "3.4.2"
+MRSFAST_VERSION := "3.4.3"
 BUILD_DATE := "$(shell date)"
 
 CC?= gcc

--- a/Reads.c
+++ b/Reads.c
@@ -432,6 +432,7 @@ int initRead(char *fileName1, char *fileName2)
 		_r_buf2 = getMem(10000000);
 		_r_buf2_pos = getMem(sizeof(int));
 		_r_buf2_size = getMem(sizeof(int));
+		*_r_buf2_size = *_r_buf2_pos = 0;
 	}
 	else
 	{


### PR DESCRIPTION
## Summary

This PR bundles two small fixes that allow mrsFAST-Ultra to build cleanly on modern Linux toolchains (GCC ≥ 10, default-PIE distributions) and resolves a paired-end segfault caused by an uninitialized buffer counter in `initRead()`. The version is bumped to **3.4.3**.

The changes are confined to `Makefile` and `Reads.c` (1 line each in the source; the rest is build-system).

---

## 1. Build fixes (`Makefile`)

### 1a. Add `-fcommon` to `CFLAGS`

GCC 10 switched the default from `-fcommon` to `-fno-common`. mrsFAST declares the same global symbols (e.g. tunable flags, shared counters) in multiple translation units without `extern`, so on GCC ≥ 10 the link fails with `multiple definition of …` errors.

```diff
-CFLAGS=-fno-pic -DMRSFAST_VERSION=\"$(MRSFAST_VERSION)\" -DBUILD_DATE=\"$(BUILD_DATE)\"
+CFLAGS=-fno-pic -fcommon -DMRSFAST_VERSION=\"$(MRSFAST_VERSION)\" -DBUILD_DATE=\"$(BUILD_DATE)\"
```

A proper fix would mark each global with `extern` in the header and define it once in a `.c` file, but `-fcommon` restores the historical behaviour without touching the source tree.

### 1b. Add `-no-pie` to the Linux link step (mrsfast + snp_indexer)

Most current Linux distributions configure GCC to produce position-independent executables (`-pie`) by default. mrsFAST compiles its objects with `-fno-pic`, which is incompatible with `-pie` linking — the link aborts with `relocation R_X86_64_32 against ‘.rodata’ can not be used when making a PIE object`.

```diff
 mrsfast: clean_executables $(objects)
 ifeq ($(shell uname -s),Linux)
-	$(CC) -w $(objects) -o $@ ${LDFLAGS} ${LIBS}
+	$(CC) -no-pie -w $(objects) -o $@ ${LDFLAGS} ${LIBS}
 else
 	$(CC) -Wl,-no_pie -fno-pic -w $(objects) -o $@ ${LDFLAGS} ${LIBS}
 endif
 …
 snp_indexer: clean_executables SNPIndexer.o
-	$(CC) SNPIndexer.o -o $@ ${LDFLAGS} ${LIBS}
+	$(CC) -no-pie SNPIndexer.o -o $@ ${LDFLAGS} ${LIBS}
```

The macOS branch already passes `-Wl,-no_pie`; this brings Linux in line.

### 1c. Fix the SSE4 detection awk expression

The existing rule checked `$2>=4 && $3>=4` against the GCC version string returned by `gcc -dumpversion`. On modern compilers (e.g. `gcc 11.4.0`, `gcc 12.x`), `-dumpversion` returns just the major number (`11`, `12`), so `$2` and `$3` are empty and SSE4 is silently disabled — even on hardware that supports it.

The fix accepts any GCC ≥ 4.4 by treating the major version as the primary gate:

```diff
-echo $$sc.$$gv | awk -F. '{if($$1>0 && $$2>=4 && $$3>=4) print "-DSSE4=1 -msse4.2"; else print "-DSSE4=0"}'
+echo $$sc.$$gv | awk -F. '{if($$1>0 && ($$2>4 || ($$2==4 && $$3>=4))) print "-DSSE4=1 -msse4.2"; else print "-DSSE4=0"}'
```

Applied to both the Linux and macOS branches.

---

## 2. Paired-end segfault fix (`Reads.c`)

In `initRead()`, the buffer counters for the **first** input file are explicitly zeroed:

```c
*_r_buf1_size = *_r_buf1_pos = 0;
```

…but the matching initialisation for the **second** file (paired-end with separate `fileName2`) was missing. `getMem()` is not guaranteed to hand back zeroed memory, so the very first read of `*_r_buf2_pos` / `*_r_buf2_size` consumed garbage and downstream pointer arithmetic dereferenced out-of-bounds memory, producing a segfault on the first paired-end batch.

```diff
 if ( pairedEndMode && fileName2 != NULL )
 {
     _r_buf2 = getMem(10000000);
     _r_buf2_pos = getMem(sizeof(int));
     _r_buf2_size = getMem(sizeof(int));
+    *_r_buf2_size = *_r_buf2_pos = 0;
 }
```

One line, symmetric with the `_r_buf1` initialiser two lines above.

---

## 3. Version bump

```diff
-MRSFAST_VERSION := "3.4.2"
+MRSFAST_VERSION := "3.4.3"
```

---

## Test plan

- [ ] `make` succeeds on Linux with GCC 10, 11, 12, and 13 (previously failed at the link step on all four).
- [ ] `make` still succeeds on macOS / clang (the macOS branch is untouched).
- [ ] `./mrsfast --search …` runs single-end mapping without regression.
- [ ] `./mrsfast --pe --seq1 a.fq --seq2 b.fq …` no longer segfaults on the first batch (this was the reproducer for fix #2).
- [ ] `./mrsfast --pe --seqcomp --seq1 a.fq.gz --seq2 b.fq.gz …` also runs to completion (covers the compressed PE path).
- [ ] On a CPU advertising SSE4 with GCC ≥ 4.4, the build picks up `-DSSE4=1 -msse4.2` (verifiable by adding `$(info CFLAGS=$(CFLAGS))` to the Makefile).

## Notes for reviewers

- All four commits are author-signed (`ndescostes`) and were already merged into our downstream fork (`descostesn/mrsfast-copy`) as PR #1 (`errorcompile`) and PR #2 (`segmentation-fault`). They are squashable if you prefer a single upstream commit.
- The Makefile changes are conservative — they only *add* flags and tighten the SSE4 awk expression; they do not change defaults for older GCCs.
